### PR TITLE
Update modis session auth

### DIFF
--- a/modis_tools/auth.py
+++ b/modis_tools/auth.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import stat
 
 from requests import sessions
-from requests.auth import HTTPBasicAuth, HTTPProxyAuth
+from requests.auth import HTTPBasicAuth
 
 from .constants.urls import URLs
 
@@ -46,21 +46,6 @@ class ModisSession:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.session.close()
-
-    def use_proxy_auth(self) -> HTTPBasicAuth:
-        """Switch to use HTTPProxyAuth, return the previous auth"""
-        old_auth = self.session.auth
-        self.session.auth = HTTPProxyAuth(self.username, self.password)
-        return old_auth
-
-    def set_auth(self, auth: Union[HTTPBasicAuth, HTTPProxyAuth]) -> None:
-        """Set authentication to <auth>
-
-        Args:
-            auth (Union[HTTPBasicAuth, HTTPProxyAuth]): Authentication to use
-        """
-
-        self.session.auth = auth
 
 
 def has_download_cookies(session):

--- a/modis_tools/auth.py
+++ b/modis_tools/auth.py
@@ -9,6 +9,7 @@ import stat
 
 from requests import sessions
 from requests.auth import HTTPBasicAuth
+from requests_ntlm import HttpNtlmAuth
 
 from .constants.urls import URLs
 
@@ -22,13 +23,14 @@ class ModisSession:
         self,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        auth: Optional[HTTPBasicAuth] = None,
+        auth: Optional[Union[HTTPBasicAuth,HttpNtlmAuth]] = None,
     ):
+        self.user_info = (username, password)
         self.session = sessions.Session()
         if auth:
             self.session.auth = auth
         elif username is not None and password is not None:
-            self.session.auth = HTTPBasicAuth(username, password)
+            self.session.auth = HttpNtlmAuth(username, password)
         else:
             try:
                 username, _, password = netrc().authenticators(URLs.URS.value)

--- a/modis_tools/granule_handler.py
+++ b/modis_tools/granule_handler.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, List, Literal, Optional, Type, TypeVar, Union
 from urllib.parse import urlsplit
 
 from pydantic.networks import HttpUrl
+from requests.auth import HTTPProxyAuth
 from requests.models import Response
 from requests.sessions import Session
 
@@ -180,9 +181,11 @@ class GranuleHandler:
         https_url = split_result._replace(scheme="https").geturl()
         location_resp = session.get(https_url, allow_redirects=False)
         if location_resp.status_code == 401:
-            old_session = modis_session.use_proxy_auth()
-            location_resp = session.get(https_url, allow_redirects=False)
-            modis_session.set_auth(old_session)
+            location_resp = session.get(
+                https_url,
+                allow_redirects=False,
+                auth=HTTPProxyAuth(modis_session.username, modis_session.password),
+            )
         location = location_resp.headers.get("Location")
         if not location:
             raise FileNotFoundError("No file location found")

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 markers =
     integration_test: marks tests as integration slow (deselect with 'pytest -m "not integration_test"', only evaluate with 'pytest -m integration_test')
     serial
+
+testpaths =
+    tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pydantic==1.*
 python-dateutil==2.*
 shapely==1.*
 tqdm>=4.42.0
-requests_ntlm==1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic==1.*
 python-dateutil==2.*
 shapely==1.*
 tqdm>=4.42.0
+requests_ntlm = 1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pydantic==1.*
 python-dateutil==2.*
 shapely==1.*
 tqdm>=4.42.0
-requests_ntlm = 1.*
+requests_ntlm==1.*


### PR DESCRIPTION
## Description

- Added support to try `HTTPProxyAuth` for the first data download of a session.
- No change to the public interface, and fully backward compatible
- The issue was getting `No file location found`, when we tried to  download MOD13A2 tiles this week. When we checked the download link on the browser, the authentication request was directed to `urs.earthdata.nasa.gov` and can no longer be accomplished with `HTTPBasicAuth`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] RP can download granules successfully now
- [ ] all existing unit tests still pass

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨