### PR TITLE
switched from str to AnyUrl in the granule model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ session = ModisSession(username=username, password=password)
 
 # Query the MODIS catalog for collections
 collection_client = CollectionApi(session=session)
-collections = collection_client.query(short_name="MOD13A1", version="006")
+collections = collection_client.query(short_name="MOD13A1", version="061")
 
 # Query the selected collection for granules
 granule_client = GranuleApi.from_collection(collections[0], session=session)
@@ -94,7 +94,7 @@ You can interact with the Earthdata Search API to browse collections and granule
 
 ```python
 # Collections query returns a list of matching collections
-collections = collection_client.query(short_name="MOD13A1", version="006")
+collections = collection_client.query(short_name="MOD13A1", version="061")
 
 # Create a GranuleApi from a Collection, the `concept_id` search parameter is set
 # to the collection

--- a/modis_tools/constants/urls.py
+++ b/modis_tools/constants/urls.py
@@ -8,5 +8,6 @@ class URLs(Enum):
     API: str = "cmr.earthdata.nasa.gov"
     URS: str = "urs.earthdata.nasa.gov"
     RESOURCE: str = "e4ftl01.cr.usgs.gov"
+    MOD11A2_V061_RESOURCE: str = "data.lpdaac.earthdatacloud.nasa.gov"
     NSIDC_RESOURCE: str = "n5eil01u.ecs.nsidc.org"
     EARTHDATA: str = ".earthdata.nasa.gov"

--- a/modis_tools/granule_handler.py
+++ b/modis_tools/granule_handler.py
@@ -101,6 +101,7 @@ class GranuleHandler:
             if link.href.host in [
                 URLs.RESOURCE.value,
                 URLs.NSIDC_RESOURCE.value,
+                URLs.MOD11A2_V061_RESOURCE.value,
             ] and link.href.path.endswith(ext):
                 return link.href
         raise Exception("No matching link found")

--- a/modis_tools/models.py
+++ b/modis_tools/models.py
@@ -3,14 +3,15 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, HttpUrl, AnyUrl
 
 
 # Shared structure
 class ApiLink(BaseModel):
     rel: HttpUrl
     hreflang: str
-    href: HttpUrl
+    href: AnyUrl
+    type: Optional[str] = None
 
     @property
     def rel(self, val: str) -> str:

--- a/modis_tools/resources.py
+++ b/modis_tools/resources.py
@@ -7,7 +7,6 @@ from .decorators import params_args
 from .models import Collection, CollectionFeed, Granule, GranuleFeed
 from .request_helpers import DateParams, SpatialQuery
 
-
 class CollectionApi(ModisApi):
     """API for MODIS's 'collections' resource"""
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This hotfix allows users to download `MOD11A2` version `061`. The tiny change is switching the pydantic model for the link to the `hdf` file from `HttpUrl` to `AnyUrl`, this allows the links to have both `s3://`, `http://` and `https://` schemas.

Closes #24

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Next Steps
- [x] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨