### PR TITLE
Fix pydantic for aws s3 urls

### DIFF
--- a/modis_tools/resources.py
+++ b/modis_tools/resources.py
@@ -37,6 +37,17 @@ DEFAULT_GRANULE_PARAMS = {
 }
 
 
+def remove_s3_urls(feed):
+    """Remove S3 urls from the granule query result dictionary
+    :param feed query result dictionary
+    :type dict
+    """
+    for entry in feed['entry']:
+        for link in entry['links']:
+            if 's3://' in link['href']:
+                entry['links'].remove(link)
+
+
 class GranuleApi(ModisApi):
     """API for MODIS's 'granules' resource"""
 
@@ -115,6 +126,7 @@ class GranuleApi(ModisApi):
             try:
                 resp = self.no_auth.get(params=params, auth=None)
                 feed = resp.json()["feed"]
+                remove_s3_urls(feed)
                 granule_feed = GranuleFeed(**feed)
             except (json.JSONDecodeError, KeyError, IndexError) as err:
                 raise Exception("Can't read response") from err


### PR DESCRIPTION
When downloading from a collection such as MOD13A1 v061, the granule search will retrieve results hosted in an amazon s3 volume. Pydantic will not recognize such urls (s3://) and throw an exception: pydantic.error_wrappers.ValidationError: 8 validation errors for GranuleFeed

This commit removes the s3 urls from the query results.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
I tried downloading data from MOD13A1 v061:
```python
from modis_tools.auth import ModisSession
from modis_tools.resources import CollectionApi, GranuleApi
from modis_tools.granule_handler import GranuleHandler
from datetime import datetime

session = ModisSession(...)
collection_client = CollectionApi(session=session)

col = collection_client.query(short_name='MOD13A1', version='061')
granule_client = GranuleApi.from_collection(col[0], session=session)
granules = granule_client.query(
            start_date=datetime(2023, 6, 8),
            end_date=datetime(2023, 6, 27),
            bounding_box=(5, 35, 5, 35)
        )
GranuleHandler.download_from_granules(granules, session, path='.')
```
which throws:
```
    granule_feed = GranuleFeed(**feed)
  File "pydantic\main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 8 validation errors for GranuleFeed
entry -> 0 -> links -> 1 -> href
  URL scheme not permitted (type=value_error.url.scheme; allowed_schemes={'http', 'https'})
```

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨