### PR TITLE
feature/fix_return_mismatch

### DIFF
--- a/modis_tools/granule_handler.py
+++ b/modis_tools/granule_handler.py
@@ -68,6 +68,8 @@ class GranuleHandler:
             position=0,
             unit="file",
         )
+        if isinstance(result[0], list):
+            result = [item for sublist in result for item in sublist]
         return result
 
     @classmethod


### PR DESCRIPTION
resolve err where when multithreading we return a list of lists of urls, not a list of urls

## Description

When downloading granules in a multithreaded environment, the return value is not a list of Paths but a list of a list of paths

Closes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran in debug mode with most multithreading and single threading and demonstrated that the multithread code returns a list of lists

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨