### PR TITLE
Fix: Added setuptools as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic==1.*
 python-dateutil==2.*
 shapely==2.*
 tqdm>=4.42.0
+setuptools==69.2.0;python_version>='3.12'


### PR DESCRIPTION
## Description

- I basically added `setuptools` as a dependency in the `requirements.txt` file conditioning the python version >= 3.12. 
- The issue occurred because in Python 3.12 `setuptools` is no longer installed by default on virtual environment creation. (See https://docs.python.org/3/whatsnew/3.12.html and https://github.com/python/cpython/issues/95299)

From my end, now the package is getting installed without any error without breaking any change.

Closes [Issue #48](https://github.com/fraymio/modis-tools/issues/48)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A: Local installation successful

<details>
<summary>Click to expand the installation results</summary>

```
(env) PS D:\modis-tools> pip install . 
Processing d:\modis-tools
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: requests==2.* in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (2.31.0)
Requirement already satisfied: pydantic==1.* in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (1.10.15)
Requirement already satisfied: python-dateutil==2.* in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (2.9.0.post0)
Requirement already satisfied: shapely==2.* in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (2.0.3)
Requirement already satisfied: tqdm>=4.42.0 in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (4.66.2)
Requirement already satisfied: setuptools==69.2.0 in d:\modis-tools\env\lib\site-packages (from modis_tools==1.1.3) (69.2.0)
Requirement already satisfied: typing-extensions>=4.2.0 in d:\modis-tools\env\lib\site-packages (from pydantic==1.*->modis_tools==1.1.3) (4.11.0)
Requirement already satisfied: six>=1.5 in d:\modis-tools\env\lib\site-packages (from python-dateutil==2.*->modis_tools==1.1.3) (1.16.0)
Requirement already satisfied: charset-normalizer<4,>=2 in d:\modis-tools\env\lib\site-packages (from requests==2.*->modis_tools==1.1.3) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in d:\modis-tools\env\lib\site-packages (from requests==2.*->modis_tools==1.1.3) (3.6)
Requirement already satisfied: urllib3<3,>=1.21.1 in d:\modis-tools\env\lib\site-packages (from requests==2.*->modis_tools==1.1.3) (2.2.1)
Requirement already satisfied: certifi>=2017.4.17 in d:\modis-tools\env\lib\site-packages (from requests==2.*->modis_tools==1.1.3) (2024.2.2)
Requirement already satisfied: numpy<2,>=1.14 in d:\modis-tools\env\lib\site-packages (from shapely==2.*->modis_tools==1.1.3) (1.26.4)
Requirement already satisfied: colorama in d:\modis-tools\env\lib\site-packages (from tqdm>=4.42.0->modis_tools==1.1.3) (0.4.6)
Building wheels for collected packages: modis_tools
  Building wheel for modis_tools (pyproject.toml) ... done
  Created wheel for modis_tools: filename=modis_tools-1.1.3-py3-none-any.whl size=26819 sha256=d94d8c36f42fb8defddbfa13799f0e8589950793348ef7687319a84ed2036a90
  Stored in directory: c:\users\himanshu\appdata\local\pip\cache\wheels\01\e1\2a\2c600359deaa0de3e210b32c566ec0bf5f9c5251a2cf9efc8d
Successfully built modis_tools
Installing collected packages: modis_tools
Successfully installed modis_tools-1.1.3
```

</details>

- [x] Test B: Local testing successful

<details>
<summary>Click to expand the testing results</summary>

```
(env) PS D:\modis-tools> pytest
============================================================================ test session starts =============================================================================
platform win32 -- Python 3.12.1, pytest-8.1.1, pluggy-1.4.0
rootdir: D:\modis-tools
configfile: pytest.ini
testpaths: tests
collected 38 items

tests\test_api.py ..........                                                                                                                                            [ 26%]
tests\test_auth.py ..........                                                                                                                                           [ 52%]
tests\test_models.py ..                                                                                                                                                 [ 57%] 
tests\test_request_helpers.py .........ssss...                                                                                                                          [100%]

======================================================================= 34 passed, 4 skipped in 0.47s ======================================================================== 
```

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Next Steps

- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨