### PR TITLE
Added LAADS Earthdata Cloud URL

### DIFF
--- a/modis_tools/constants/urls.py
+++ b/modis_tools/constants/urls.py
@@ -12,5 +12,6 @@ class URLs(Enum):
     NSIDC_RESOURCE: str = "n5eil01u.ecs.nsidc.org"
     EARTHDATA: str = ".earthdata.nasa.gov"
     LAADS_RESOURCE: str = "ladsweb.modaps.eosdis.nasa.gov"
+    LAADS_CLOUD_RESOURCE: str = "data.laadsdaac.earthdatacloud.nasa.gov"
     MODISA_L3b_CHL_V061_RESOURCE: str = "oceancolor.gsfc.nasa.gov"
     MODISA_L3b_CHL_V061_RESOURCE_SCI: str = "oceandata.sci.gsfc.nasa.gov"

--- a/modis_tools/granule_handler.py
+++ b/modis_tools/granule_handler.py
@@ -106,6 +106,7 @@ class GranuleHandler:
                 URLs.NSIDC_RESOURCE.value,
                 URLs.MOD11A2_V061_RESOURCE.value,
                 URLs.LAADS_RESOURCE.value,
+		URLs.LAADS_CLOUD_RESOURCE.value,
                 URLs.MODISA_L3b_CHL_V061_RESOURCE.value,
                 URLs.MODISA_L3b_CHL_V061_RESOURCE_SCI.value,
             ] and link.href.path.endswith(ext):


### PR DESCRIPTION
## Description

- LAADS DAAC data has moved to the cloud - as detailed on this web page:
https://ladsweb.modaps.eosdis.nasa.gov/cloud/

- This caused the error "No matching link found" when trying to download level 1B hdf files.

- I've updated `constants/urls.py` to add the new URL "data.laadsdaac.earthdatacloud.nasa.gov" and updated the corresponding list in `granule_handler.py`.
- I've left the old URL "ladsweb.modaps.eosdis.nasa.gov" in the list as some other files (e.g. jpg preview images) are still hosted there.


Closes issue #53 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A: Successfully downloaded hdf files for products which previously raised the error e.g. `(short_name="MYD021KM", version="6.1")`

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨