### PR TITLE
switch to CMR-Search-After

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python_version>=3.12
 requests==2.*
 pydantic==1.*
 python-dateutil==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+python_version>=3.12
 requests==2.*
 pydantic==1.*
 python-dateutil==2.*
 shapely==2.*
 tqdm>=4.42.0
-setuptools==69.2.0;python_version>='3.12'
+setuptools==69.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python >= 3.9
 requests==2.*
 pydantic==1.*
 python-dateutil==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python >= 3.9
 requests==2.*
 pydantic==1.*
 python-dateutil==2.*


### PR DESCRIPTION
## Description

Downloading data error out. Inspecting the response yielded:
```
'CMR is currently experiencing too many scroll searches to complete this request.\n            Scroll is deprecated in CMR. Please consider switching your scroll requests to use\n            search-after. See\n            https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after.\n            This will make your workflow simpler (no more clear-scroll calls) and improve the\n            stability of both your searches and CMR. Thank you!'
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Running the example in the README returns the same number of granules as on main.
```
from modis_tools.auth import ModisSession
from modis_tools.resources import CollectionApi, GranuleApi

username="***"
password="***"

# Authenticate a session
session = ModisSession(username=username, password=password)

# Query the MODIS catalog for collections
collection_client = CollectionApi(session=session)
collections = collection_client.query(short_name="MOD13A1", version="061")

# Query the selected collection for granules
granule_client = GranuleApi.from_collection(collections[0], session=session)

# Filter the selected granules via spatial and temporal parameters
nigeria_bbox = [2.1448863675, 4.002583177, 15.289420717, 14.275061098]
nigeria_granules = granule_client.query(start_date="2016-01-01", end_date="2018-12-31", bounding_box=nigeria_bbox)

print(len(list(nigeria_granules)))
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Next Steps
- [ ] Assign a reviewer based on the [code owner document](https://github.com/fraymio/modis_tools/blob/main/.github/CODEOWNERS).

- [ ] Once your review is approved, merge and delete the feature branch

On behalf of the Modis Tools Dev Team, thank you for your hard work! ✨